### PR TITLE
set up lograge and newrelic logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'sprockets-rails'
 gem 'stimulus-rails'
 gem 'turbo-rails'
 gem 'view_component'
+gem 'lograge'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,11 @@ GEM
     jsbundling-rails (1.1.1)
       railties (>= 6.0.0)
     json (2.6.3)
+    lograge (0.12.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -172,6 +177,8 @@ GEM
     redis-client (0.14.1)
       connection_pool
     regexp_parser (2.8.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.5)
     rubocop (1.52.0)
       json (~> 2.3)
@@ -237,6 +244,7 @@ DEPENDENCIES
   hiredis
   honeybadger (~> 4.0)
   jsbundling-rails (~> 1.0)
+  lograge
   newrelic_rpm
   nokogiri (>= 1.13.6)
   pg (< 2)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,8 +57,7 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = Logger::Formatter.new
+  config.log_formatter = ::NewRelic::Agent::Logging::DecoratingFormatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.lograge.enabled = true
+end


### PR DESCRIPTION
We enable lograge everywhere (to reduce the number of lines) and newrelic logging in production (to get better-looking logs in newrelic UI).