### PR TITLE
add show_names flag in API

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -8,45 +8,40 @@ module Api
       def release
         return render_error_json(error: MISSING_MODEL_ERROR) if current_model.nil?
 
-        players = current_model.players_for_release_api(release_id:, limit: page_size, offset:)
-        Places.add_top_and_bottom_places!(players)
-        Places.add_previous_top_and_bottom_places!(players)
+        @players = fetch_players
 
-        tournaments = current_model.player_ratings_for_release(release_id:)
-        players.each do |player|
-          player['tournaments'] = tournaments.fetch(player['player_id'], [])
+        Places.add_top_and_bottom_places!(@players)
+        Places.add_previous_top_and_bottom_places!(@players)
+
+        add_rating_components!
+
+        render_paged_json(metadata: release_metadata, items: @players, all_items_count: players_in_release_count)
+      end
+
+      def add_names?
+        params[:show_names] == 'true'
+      end
+
+      def fetch_players
+        if add_names?
+          current_model.players_with_names_for_release_api(release_id:, limit: page_size, offset:)
+        else
+          current_model.players_for_release_api(release_id:, limit: page_size, offset:)
         end
+      end
 
-        metadata = {
+      def add_rating_components!
+        tournament_components = current_model.player_ratings_components_for_release(release_id:)
+        @players.each do |player|
+          player['tournaments'] = tournament_components.fetch(player['player_id'], [])
+        end
+      end
+
+      def release_metadata
+        {
           model: current_model.name,
           release_id:
         }
-
-        render_paged_json(metadata:, items: players, all_items_count: players_in_release_count)
-      end
-
-      def show
-        return render_error_json(error: MISSING_MODEL_ERROR) if current_model.nil?
-
-        releases = current_model.player_releases(player_id:).map(&:to_h)
-        tournaments = current_model.player_tournaments(player_id:)
-
-        tournaments_hash = tournaments.each_with_object({}) do |tournament, hash|
-          next unless tournament.in_rating
-
-          (hash[tournament['release_id']] ||= []) << tournament.to_h.except(:release_id)
-        end
-
-        releases.each do |release|
-          release['tournaments'] = tournaments_hash[release[:id]]
-        end
-
-        metadata = {
-          model: current_model.name,
-          player_id:
-        }
-
-        render_json(metadata:, items: releases)
       end
 
       def players_in_release_count
@@ -61,8 +56,39 @@ module Api
                         end
       end
 
+      def show
+        return render_error_json(error: MISSING_MODEL_ERROR) if current_model.nil?
+
+        @releases = current_model.player_releases(player_id:).map(&:to_h)
+        add_tournaments!
+        render_json(metadata: player_metadata, items: @releases)
+      end
+
       def player_id
         @player_id ||= params[:player_id].to_i
+      end
+
+      def add_tournaments!
+        tournaments = current_model.player_tournaments(player_id:)
+
+        tournaments_hash = tournaments.each_with_object({}) do |tournament, hash|
+          next unless tournament.in_rating
+
+          (hash[tournament['release_id']] ||= []) << tournament.to_h.except(:release_id)
+        end
+
+        @releases.each do |release|
+          release['tournaments'] = tournaments_hash[release[:id]]
+        end
+      end
+
+      def player_metadata
+        metadata = {
+          model: current_model.name,
+          player_id:
+        }
+        metadata[:name] = current_model.player_name_api(player_id:) if add_names?
+        metadata
       end
     end
   end

--- a/app/controllers/api/v1/tournaments_controller.rb
+++ b/app/controllers/api/v1/tournaments_controller.rb
@@ -8,16 +8,40 @@ module Api
       def show
         return render_error_json(error: MISSING_MODEL_ERROR) if current_model.nil?
 
-        @tournament_id = params[:tournament_id].to_i
-        results = current_model.tournament_ratings(tournament_id: @tournament_id)
-        render_json(metadata:, items: results)
+        tournament_ratings = fetch_tournament_ratings
+        render_json(metadata:, items: tournament_ratings)
+      end
+
+      def add_names?
+        params[:show_names] == 'true'
+      end
+
+      def fetch_tournament_ratings
+        if add_names?
+          current_model.tournament_ratings_with_team_names(tournament_id:)
+        else
+          current_model.tournament_ratings(tournament_id:)
+        end
       end
 
       def metadata
-        {
+        metadata = {
           model: current_model.name,
           tournament_id: @tournament_id
         }
+
+        if add_names?
+          tournament_details = current_model.tournament_details(tournament_id:)
+          metadata[:title] = tournament_details.name
+          metadata[:start_date] = tournament_details.start
+          metadata[:end_date] = tournament_details.end
+        end
+
+        metadata
+      end
+
+      def tournament_id
+        @tournament_id ||= params[:tournament_id].to_i
       end
     end
   end

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -9,7 +9,7 @@ class TournamentsController < ApplicationController
 
   def show
     id = params[:tournament_id].to_i
-    details = current_model.tournaments(tournament_id: id)
+    details = current_model.tournament_details(tournament_id: id)
     return render_404 if details.name.nil?
 
     results = current_model.tournament_results(tournament_id: id)

--- a/app/lib/player_queries.rb
+++ b/app/lib/player_queries.rb
@@ -25,6 +25,16 @@ module PlayerQueries
     exec_query_for_single_value(query: sql, params: [player_id])
   end
 
+  def player_name_api(player_id:)
+    sql = <<~SQL
+      select p.first_name || ' ' || last_name as name
+      from public.players p
+      where p.id = $1
+    SQL
+
+    exec_query_for_single_value(query: sql, params: [player_id])
+  end
+
   def player_tournaments(player_id:)
     sql = <<~SQL
       select rel.id as release_id, t.id as id, t.title as name, t.end_datetime as date,

--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -76,6 +76,34 @@ module ReleaseQueries
     exec_query_for_hash_array(query: sql, params: [release_id, limit, offset])
   end
 
+  def teams_with_names_for_release_api(release_id:, limit:, offset:)
+    sql = <<~SQL
+      with ordered as (
+          select id, row_number() over (order by date)
+          from #{name}.release
+      ),
+      releases as (
+          select o1.id as release_id, o2.id as prev_release_id
+          from ordered o1
+          left join ordered o2 on o1.row_number = o2.row_number + 1
+      )
+      select r.*, prev.place as previous_place, r.place - prev.place as place_change,
+        t.title as team_name, towns.title as city
+      from #{name}.team_ranking r
+      left join #{name}.team_ranking prev
+        on r.team_id = prev.team_id
+          and prev.release_id = (select prev_release_id from releases where release_id = $1)
+      left join public.teams t on t.id = r.team_id
+      left join public.towns towns on t.town_id = towns.id
+      where r.release_id = $1
+      order by row_number() over (order by r.rating desc)
+      limit $2
+      offset $3;
+    SQL
+
+    exec_query_for_hash_array(query: sql, params: [release_id, limit, offset])
+  end
+
   def tournaments_in_release_by_team(release_id:)
     sql = <<~SQL
       select t.id as tournament_id, tr.team_id, tr.rating, tr.rating_change, t.maii_rating as in_rating


### PR DESCRIPTION
Add `show_names=true` to teams, players, and tournaments endpoints to get not only IDs, but also names of players and teams.

For players: adds `name`.
For teams: adds `team_name` and `city`.
For tournaments: adds `base_team_name`, `team_name`, and `city`.