### PR TITLE
allow robots to scrape only the main model

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /
+Allow: /b


### PR DESCRIPTION
Scrapers generate a lot of useless traffic trying to get pages for deleted models. Only the main model results should be searchable from the outside.