### PR TITLE
use larger statement timeout only for views updating

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ COPY --from=build --chown=rails:rails /rails /rails
 
 # Deployment options
 ENV RAILS_LOG_TO_STDOUT="1" \
-    RAILS_SERVE_STATIC_FILES="true"
+    RAILS_SERVE_STATIC_FILES="true" \
+    DATABASE_STATEMENT_TIMEOUT=5000
 
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]

--- a/app/lib/materialized_views.rb
+++ b/app/lib/materialized_views.rb
@@ -12,10 +12,21 @@ class MaterializedViews
   end
 
   def recreate_all
+    increase_statement_timeout!
     definitions.each { |definition| create_or_refresh_view(definition) }
+    decrease_statement_timeout!
   end
 
   private
+
+  def increase_statement_timeout!
+    ActiveRecord::Base.connection.execute('SET statement_timeout TO 120000;')
+  end
+
+  def decrease_statement_timeout!
+    default_timeout = ENV.fetch('DATABASE_STATEMENT_TIMEOUT', 5000)
+    ActiveRecord::Base.connection.execute("SET statement_timeout TO #{default_timeout};")
+  end
 
   def definitions
     [player_ranking, team_ranking]

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   url: <%= ENV.fetch('DATABASE_URL', "postgres://postgres:@localhost:5432") %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5)%>
   variables:
-    statement_timeout: 120000
+    statement_timeout: <%= ENV.fetch("DATABASE_STATEMENT_TIMEOUT", 5000)%>
 
 production:
   <<: *default


### PR DESCRIPTION
We need a longer timeout to refresh materialized views, but not for regular read-only queries.