### PR TITLE
improve player releases endpoint performance

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -31,7 +31,8 @@ module Api
       end
 
       def add_rating_components!
-        tournament_components = current_model.player_ratings_components_for_release(release_id:)
+        player_ids = @players.map { |player| player["player_id"] }
+        tournament_components = current_model.player_ratings_components_for_release(release_id:, player_ids:)
         @players.each do |player|
           player["tournaments"] = tournament_components.fetch(player["player_id"], [])
         end

--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -197,15 +197,17 @@ module ReleaseQueries
       result_class: ReleasePlayer)
   end
 
-  def player_ratings_components_for_release(release_id:)
+  def player_ratings_components_for_release(release_id:, player_ids:)
+    placeholders = build_placeholders(start_with: 2, count: player_ids.size)
+
     sql = <<~SQL
       select player_id, tournament_id,
           cur_score as current_rating, initial_score as initial_rating
       from #{name}.player_rating_by_tournament
-      where release_id = $1
+      where release_id = $1 and player_id in (#{placeholders})
     SQL
 
-    exec_query_for_hash(query: sql, params: [release_id], group_by: "player_id")
+    exec_query_for_hash(query: sql, params: [release_id] + player_ids, group_by: "player_id")
   end
 
   def players_for_release_api(release_id:, limit:, offset:)

--- a/app/lib/team_queries.rb
+++ b/app/lib/team_queries.rb
@@ -104,7 +104,7 @@ module TeamQueries
   end
 
   def teams_ranking(list_of_team_ids:, date:)
-    placeholders = 2.upto(list_of_team_ids.size + 1).map { |index| "$#{index}" }.join(", ")
+    placeholders = build_placeholders(start_with: 2, count: list_of_team_ids.size)
 
     sql = <<~SQL
       select tr.team_id, tr.place

--- a/app/models/concerns/cacheable.rb
+++ b/app/models/concerns/cacheable.rb
@@ -31,6 +31,10 @@ module Cacheable
       .map { |row| result_class.new(row) }
   end
 
+  def build_placeholders(start_with:, count:)
+    start_with.upto(count + start_with - 1).map { |index| "$#{index}" }.join(", ")
+  end
+
   private
 
   def cache_namespace

--- a/app/models/concerns/cacheable.rb
+++ b/app/models/concerns/cacheable.rb
@@ -19,7 +19,6 @@ module Cacheable
 
   def exec_query_for_hash(query:, params: nil, group_by:, cache: false)
     exec_query_with_cache(query, params, cache:)
-      .to_a
       .each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, hash|
         hash[row.delete(group_by)] << row
       end
@@ -27,7 +26,6 @@ module Cacheable
 
   def exec_query(query:, params: nil, result_class:, cache: false)
     exec_query_with_cache(query, params, cache:)
-      .to_a
       .map { |row| result_class.new(row) }
   end
 


### PR DESCRIPTION
`player_ratings_components_for_release` was building a lookup hash for all players in a release, which used a lot of memory. We now filter by the list of players present on a JSON response page.

We build a list of placeholders for `in ($2, $3, $4)` in two places now, so this got moved into a `build_placeholders` method.

Additionally, `exec_query_with_cache` returns `ActiveRecord::Result` which is an Enumerable, so there’s no need for a conversion before calling `map` or `each_with_object`.