### PR TITLE
return empty array for pages with no players

### DIFF
--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -199,12 +199,13 @@ module ReleaseQueries
 
   def player_ratings_components_for_release(release_id:, player_ids:)
     placeholders = build_placeholders(start_with: 2, count: player_ids.size)
+    player_filter = "and player_id in (#{placeholders})"
 
     sql = <<~SQL
       select player_id, tournament_id,
           cur_score as current_rating, initial_score as initial_rating
       from #{name}.player_rating_by_tournament
-      where release_id = $1 and player_id in (#{placeholders})
+      where release_id = $1 #{player_filter unless player_ids.empty?}
     SQL
 
     exec_query_for_hash(query: sql, params: [release_id] + player_ids, group_by: "player_id")


### PR DESCRIPTION
A request like <https://rating.maii.li/api/v1/b/players/123.json?page=125> was failing with `PG::SyntaxError: ERROR:  syntax error at or near ")"\nLINE 4: where release_id = $1 and player_id in ()`.

Instead, we should return an empty array in `items`.