### PR TITLE
Ignore teams without roster continuity in trueDL calculations

### DIFF
--- a/app/lib/r_calculator.rb
+++ b/app/lib/r_calculator.rb
@@ -20,7 +20,7 @@ class RCalculator
   def ratings
     players_ratings = @model.players_ratings_on_date(players:, date:).pluck("rating")
     rt = calculate_rt(players_ratings)
-    base_players = @model.base_roster_on_date(team_id:, date:).pluck("player_id")
+    base_players = @model.base_rosters_on_date(team_ids: [team_id], date:).pluck("player_id")
 
     unless RosterContinuity.has_continuity?(players:, base_players:, date:)
       return Rs.new(rt:, rg: rt, r: 0, rb: 0)
@@ -42,7 +42,7 @@ class RCalculator
   end
 
   def calculate_r
-    team_rating = @model.teams_ranking(list_of_team_ids: [team_id], date:)
+    team_rating = @model.teams_ranking(team_ids: [team_id], date:)
     return 0 if team_rating.empty?
 
     team_rating[team_id].first["rating"]

--- a/app/lib/r_calculator.rb
+++ b/app/lib/r_calculator.rb
@@ -21,7 +21,10 @@ class RCalculator
     players_ratings = @model.players_ratings_on_date(players:, date:).pluck("rating")
     rt = calculate_rt(players_ratings)
     base_players = @model.base_roster_on_date(team_id:, date:).pluck("player_id")
-    return Rs.new(rt:, rg: rt, r: 0, rb: 0) unless is_continuous_to?(base_players)
+
+    unless RosterContinuity.has_continuity?(players:, base_players:, date:)
+      return Rs.new(rt:, rg: rt, r: 0, rb: 0)
+    end
 
     base_players_ratings = @model.players_ratings_on_date(players: base_players, date:).pluck("rating")
 
@@ -50,14 +53,5 @@ class RCalculator
 
     rg = Float(r) * rt / rb
     Integer(rg.clamp(0.5 * r, [rt, r].max))
-  end
-
-  def is_continuous_to?(base_players)
-    base_team_player_count = Set.new(base_players).intersection(Set.new(@players)).size
-    has_continuity?(base_team_player_count, @players.size - base_team_player_count)
-  end
-
-  def has_continuity?(base_players, legionnaires)
-    (base_players >= 3) && (legionnaires < base_players) && (legionnaires <= 3)
   end
 end

--- a/app/lib/roster_continuity.rb
+++ b/app/lib/roster_continuity.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RosterContinuity
+  FIRST_DATE_OF_2022_RULES = Date.new(2022, 11, 18)
+
+  # @param [Enumerable] players List of IDs, e.g., roster in a specific tournament
+  # @param [Enumerable] base_players List of IDs, base roster of a team on a specific date
+  # @param [Date] date Date of a tournament: e.g., rules are different for 2021 and 2023
+  # @return [Boolean]
+  def self.has_continuity?(players:, base_players:, date:)
+    base_players_count = Set.new(base_players).intersection(Set.new(players)).size
+    legionnaires_count = players.size - base_players_count
+
+    if date >= FIRST_DATE_OF_2022_RULES
+      (base_players_count >= 3) && (legionnaires_count < base_players_count) && (legionnaires_count <= 3)
+    else
+      base_players_count >= 4
+    end
+  end
+end


### PR DESCRIPTION
TrueDL calculation has been first implemented when we did not have any continuity-related methods in rating-ui. Now that they are available, we should stop including teams without roster continuity into TrueDl calculations.

The first commit is preparation work: moving out those continuity methods into their own module.

In the second commit, besides adding the filter itself, I’ve also replaced an almost duplicate method that fetched a base roster for the current season (to display it on a team’s page) with a call to a more general `base_rosters_on_date` method.