### PR TITLE
order by *_rankings.place in releases endpoints

### DIFF
--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -70,7 +70,7 @@ module ReleaseQueries
         on r.team_id = prev.team_id
           and prev.release_id = (select prev_release_id from releases where release_id = $1)
       where r.release_id = $1
-      order by row_number() over (order by r.rating desc)
+      order by r.place
       limit $2
       offset $3;
     SQL
@@ -98,7 +98,7 @@ module ReleaseQueries
       left join public.teams t on t.id = r.team_id
       left join public.towns towns on t.town_id = towns.id
       where r.release_id = $1
-      order by row_number() over (order by r.rating desc)
+      order by r.place
       limit $2
       offset $3;
     SQL

--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -231,7 +231,7 @@ module ReleaseQueries
         on r.player_id = prev.player_id
             and prev.release_id = (select prev_release_id from releases where release_id = $1)
       where r.release_id = $1
-      order by row_number() over (order by r.rating desc)
+      order by r.place
       limit $2
       offset $3;
     SQL
@@ -262,7 +262,7 @@ module ReleaseQueries
       left join public.players p 
         on p.id = r.player_id
       where r.release_id = $1
-      order by row_number() over (order by r.rating desc)
+      order by r.place
       limit $2
       offset $3;
     SQL


### PR DESCRIPTION
We now have `place` already calculate in almost the way in the `player_rankings` view (`rank() over (partition by release_id order by rating desc`). Instead of a costly recalculation that was causing requests to time out we can reuse `place`.

The same is done for teams.