### PR TITLE
add indexes on release_id and place in player_rankings view

### DIFF
--- a/app/lib/materialized_views.rb
+++ b/app/lib/materialized_views.rb
@@ -52,7 +52,7 @@ class MaterializedViews
   def player_ranking
     ViewDefinition.new(
       name: "player_ranking",
-      index_columns: ["player_id"],
+      index_columns: %w[player_id release_id place],
       query: <<~SQL
         select rank() over (partition by release_id order by rating desc) as place,
             player_id, rating, rating_change, release_id
@@ -64,7 +64,7 @@ class MaterializedViews
   def team_ranking
     ViewDefinition.new(
       name: "team_ranking",
-      index_columns: ["team_id"],
+      index_columns: %w[team_id release_id place],
       query: <<~SQL
         select rank() over (partition by release_id order by rating desc) as place,
             team_id, rating, rating_change, release_id, trb


### PR DESCRIPTION
Requests for player releases need both a index on `release_id` (for filtering and for a join on previous releases—to get the `place_change` value) and on `place` (each release at the moment has about 50k players, so need fast results from queries like `order by place offset 40000 limit 1000`).