### PR TITLE
sort shared places by id

### DIFF
--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -70,7 +70,7 @@ module ReleaseQueries
         on r.team_id = prev.team_id
           and prev.release_id = (select prev_release_id from releases where release_id = $1)
       where r.release_id = $1
-      order by r.place
+      order by r.place, r.team_id
       limit $2
       offset $3;
     SQL
@@ -98,7 +98,7 @@ module ReleaseQueries
       left join public.teams t on t.id = r.team_id
       left join public.towns towns on t.town_id = towns.id
       where r.release_id = $1
-      order by r.place
+      order by r.place, r.team_id
       limit $2
       offset $3;
     SQL
@@ -231,7 +231,7 @@ module ReleaseQueries
         on r.player_id = prev.player_id
             and prev.release_id = (select prev_release_id from releases where release_id = $1)
       where r.release_id = $1
-      order by r.place
+      order by r.place, r.player_id
       limit $2
       offset $3;
     SQL
@@ -262,7 +262,7 @@ module ReleaseQueries
       left join public.players p 
         on p.id = r.player_id
       where r.release_id = $1
-      order by r.place
+      order by r.place, r.player_id
       limit $2
       offset $3;
     SQL


### PR DESCRIPTION
If several teams share 100th place, and page size is 100, then one of these teams could be placed on both page 1 and 2 for consecutive requests. Additional sorting by ID makes these pages stable.